### PR TITLE
Add 8.6.11 on osx-arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,8 @@ about:
   license_family: BSD
   license_file: tcl{{ version }}/license.terms
   summary: A dynamic programming language with GUI support.  Bundles Tcl and Tk.
+  dev_url: https://core.tcl-lang.org/tk/home
+  doc_url: https://www.tcl.tk/man/tcl8.6/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Add 8.6.11 on osx-arm64 and add dev, doc urls
All other platforms are on defaults already.