### PR TITLE
Build with latest zlib (1.2.12)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       module_scope.patch
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   run_exports:
     # pin to major.minor because library names have that info in them

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://downloads.sourceforge.net/tcl/tcl{{ version }}-src.tar.gz
+  - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tcl{{ version }}-src.tar.gz
     folder: tcl{{ version }}
     sha256: 8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258
-  - url: https://downloads.sourceforge.net/tcl/tk{{ version }}-src.tar.gz
+  - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tk{{ version }}-src.tar.gz
     folder: tk{{ version }}
     sha256: 5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282
     patches:


### PR DESCRIPTION
Addresses https://github.com/AnacondaRecipes/tk-feedstock/issues/6. Specifically, build with zlib 1.2.12 so BDBA scans no longer find [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032) in the tk module.