### PR TITLE
tk 8.6.14

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 * text=auto
 
+*.patch binary
+
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-*.patch binary
+*.patch text=false
 
 meta.yaml text eol=lf
 build.sh text eol=lf

--- a/recipe/0001-osx-lt-11.patch
+++ b/recipe/0001-osx-lt-11.patch
@@ -1,0 +1,18 @@
+--- unix/configure.orig	2024-04-30 16:31:23
++++ unix/configure	2024-04-30 16:31:55
+@@ -9450,9 +9450,12 @@
+ _ACEOF
+ 
+     LIBS="$LIBS -framework Cocoa -framework Carbon -framework IOKit -framework QuartzCore"
+-    if test -d "/System/Library/Frameworks/UniformTypeIdentifiers.framework"; then
+-        LIBS="$LIBS -weak_framework UniformTypeIdentifiers"
+-    fi
++#--------------------------------------------------------------------
++# UniformTypeIdentifiers requires building with at least MacOSX SDK 11.0
++#    if test -d "/System/Library/Frameworks/UniformTypeIdentifiers.framework"; then
++#        LIBS="$LIBS -weak_framework UniformTypeIdentifiers"
++#    fi
++#--------------------------------------------------------------------
+     EXTRA_CC_SWITCHES='-std=gnu99 -x objective-c'
+     TK_WINDOWINGSYSTEM=AQUA
+     if test -n "${enable_symbols}" -a "${enable_symbols}" != no; then

--- a/recipe/0002-win-unvendor-zlib.patch
+++ b/recipe/0002-win-unvendor-zlib.patch
@@ -1,0 +1,76 @@
+Unvendor zlib from makefile.vc.
+https://core.tcl-lang.org/tk/finfo?name=win/makefile.vc&m=bd9e6671712d016a&ci=e987bb51b8fce99b
+===================================================================
+--- win/makefile.vc.orig	2024-05-01 16:53:58
++++ win/makefile.vc	2024-05-01 17:05:40
+@@ -317,7 +317,7 @@
+ 	$(TMP_DIR)\uncompr.obj \
+ 	$(TMP_DIR)\zutil.obj
+ !else
+-ZLIBOBJS = $(OUT_DIR)\zdll.lib
++ZLIBOBJS = $(LIBRARY_LIB)\zdll.lib
+ !endif
+ 
+ TOMMATHOBJS = \
+@@ -445,7 +445,7 @@
+ release:    setup $(TCLSH) $(TCLSTUBLIB) dlls pkgs
+ core:	    setup $(TCLLIB) $(TCLSTUBLIB)
+ shell:	    setup $(TCLSH)
+-dlls:	    setup $(TCLREGLIB) $(TCLDDELIB) $(OUT_DIR)\zlib1.dll
++dlls:	    setup $(TCLREGLIB) $(TCLDDELIB)
+ all:	    setup $(TCLSH) $(TCLSTUBLIB) dlls $(CAT32) pkgs
+ tcltest:    setup $(TCLTEST) dlls $(CAT32)
+ install:    install-binaries install-libraries install-docs install-pkgs
+@@ -520,23 +520,6 @@
+ 	$(_VC_MANIFEST_EMBED_DLL)
+ !endif
+ 
+-!if "$(MACHINE)" == "ARM64"
+-$(OUT_DIR)\zlib1.dll:	$(COMPATDIR)\zlib\win64-arm\zlib1.dll
+-	$(COPY) $(COMPATDIR)\zlib\win64-arm\zlib1.dll $(OUT_DIR)\zlib1.dll
+-$(OUT_DIR)\zdll.lib:	$(COMPATDIR)\zlib\win64-arm\zdll.lib
+-	$(COPY) $(COMPATDIR)\zlib\win64-arm\zdll.lib $(OUT_DIR)\zdll.lib
+-!elseif "$(MACHINE)" == "IX86"
+-$(OUT_DIR)\zlib1.dll:	$(COMPATDIR)\zlib\win32\zlib1.dll
+-	$(COPY) $(COMPATDIR)\zlib\win32\zlib1.dll $(OUT_DIR)\zlib1.dll
+-$(OUT_DIR)\zdll.lib:	$(COMPATDIR)\zlib\win32\zdll.lib
+-	$(COPY) $(COMPATDIR)\zlib\win32\zdll.lib $(OUT_DIR)\zdll.lib
+-!else
+-$(OUT_DIR)\zlib1.dll:	$(COMPATDIR)\zlib\win64\zlib1.dll
+-	$(COPY) $(COMPATDIR)\zlib\win64\zlib1.dll $(OUT_DIR)\zlib1.dll
+-$(OUT_DIR)\zdll.lib:	$(COMPATDIR)\zlib\win64\zdll.lib
+-	$(COPY) $(COMPATDIR)\zlib\win64\zdll.lib $(OUT_DIR)\zdll.lib
+-!endif
+-
+ pkgs:
+ 	@for /d %d in ($(PKGSDIR)\*) do \
+ 	  @if exist "%~fd\win\makefile.vc" ( \
+@@ -783,7 +766,7 @@
+ 	$(CCAPPCMD) $?
+ 
+ $(TMP_DIR)\tclZlib.obj: $(GENERICDIR)\tclZlib.c
+-	$(cc32) $(pkgcflags) -I$(COMPATDIR)\zlib -Fo$@ $?
++	$(cc32) $(pkgcflags) -I$(LIBRARY_INC)\zlib -Fo$@ $?
+ 
+ $(TMP_DIR)\tclPkgConfig.obj: $(GENERICDIR)\tclPkgConfig.c
+ 	$(cc32) $(pkgcflags) \
+@@ -880,11 +863,6 @@
+ $<
+ <<
+ 
+-{$(COMPATDIR)\zlib}.c{$(TMP_DIR)}.obj::
+-	$(cc32) $(pkgcflags) -Fo$(TMP_DIR)\ @<<
+-$<
+-<<
+-
+ $(TMP_DIR)\tclsh.res: $(TMP_DIR)\tclsh.exe.manifest $(WIN_DIR)\tclsh.rc
+ 
+ $(TMP_DIR)\tcltest.res: $(TMP_DIR)\tclsh.exe.manifest $(WIN_DIR)\tcltest.rc
+@@ -900,7 +878,6 @@
+ 	@$(CPY) "$(TCLLIB)" "$(BIN_INSTALL_DIR)\"
+ !endif
+ 	@$(CPY) "$(TCLIMPLIB)" "$(LIB_INSTALL_DIR)\"
+-	@$(CPY) "$(OUT_DIR)\zlib1.dll" "$(BIN_INSTALL_DIR)\"
+ !if exist($(TCLSH))
+ 	@echo Installing $(TCLSHNAME)
+ 	@$(CPY) "$(TCLSH)" "$(BIN_INSTALL_DIR)\"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -17,6 +17,7 @@ if "%ARCH%"=="32" (
 )
 
 pushd tcl%PKG_VERSION%\win
+nmake nmakehlp.exe
 nmake -f makefile.vc INSTALLDIR=%LIBRARY_PREFIX% MACHINE=%MACHINE% release
 nmake -f makefile.vc INSTALLDIR=%LIBRARY_PREFIX% MACHINE=%MACHINE% install
 if %ERRORLEVEL% GTR 0 exit 1
@@ -30,6 +31,7 @@ set INCLUDE=%INCLUDE%;c:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Includ
 :: Tk build
 
 pushd tk%PKG_VERSION%\win
+nmake nmakehlp.exe
 nmake -f makefile.vc INSTALLDIR=%LIBRARY_PREFIX% MACHINE=%MACHINE% TCLDIR=..\..\tcl%PKG_VERSION% release
 nmake -f makefile.vc INSTALLDIR=%LIBRARY_PREFIX% MACHINE=%MACHINE% TCLDIR=..\..\tcl%PKG_VERSION% install
 if %ERRORLEVEL% GTR 0 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
+# Required for UniformTypeIdentifiers (-weak_framework UniformTypeIdentifiers)
+MACOSX_SDK_VERSION:             # [osx and x86_64]
+  - "11.0"                      # [osx and x86_64]
 CONDA_BUILD_SYSROOT:            # [osx and x86_64]
-  - /opt/MacOSX10.12.sdk        # [osx and x86_64]
+  - /opt/MacOSX10.13.sdk        # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,5 @@
-# Required for UniformTypeIdentifiers (-weak_framework UniformTypeIdentifiers)
-MACOSX_SDK_VERSION:             # [osx and x86_64]
-  - "11.0"                      # [osx and x86_64]
 CONDA_BUILD_SYSROOT:            # [osx and x86_64]
-  - /opt/MacOSX10.13.sdk        # [osx and x86_64]
+  - /opt/MacOSX10.12.sdk        # [osx and x86_64]
 
 c_compiler:                     # [win]
 - vs2019                        # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,6 @@ MACOSX_SDK_VERSION:             # [osx and x86_64]
   - "11.0"                      # [osx and x86_64]
 CONDA_BUILD_SYSROOT:            # [osx and x86_64]
   - /opt/MacOSX10.13.sdk        # [osx and x86_64]
+
+c_compiler:                     # [win]
+- vs2019                        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 12395c1f3fcb6bed2938689f797ea3cdf41ed5cb6c4766eec8ac949560310630
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   run_exports:
     # pin to major.minor because library names have that info in them

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ source:
   - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tcl{{ version }}-src.tar.gz
     folder: tcl{{ version }}
     sha256: 5880225babf7954c58d4fb0f5cf6279104ce1cd6aa9b71e9a6322540e1c4de66
+    patches:                          # [win]
+      - 0002-win-unvendor-zlib.patch  # [win]
   - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tk{{ version }}-src.tar.gz
     folder: tk{{ version }}
     sha256: 8ffdb720f47a6ca6107eac2dd877e30b0ef7fac14f3a84ebbd0b3612cee41a94
@@ -33,8 +35,11 @@ requirements:
     - {{ cdt('libxau') }}                # [linux]
     - make                               # [linux]
     - patch                              # [osx and x86_64]
+    - m2-patch                           # [win]
   host:
-    - zlib  # [unix]
+    - zlib {{ zlib }}
+  run:
+    - zlib # pin through run_exports
 
 test:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,6 @@ requirements:
     - {{ cdt('libxcb') }}                # [linux]
     - {{ cdt('libxau') }}                # [linux]
     - make                               # [linux]
-    - patch                              # [not win]
-    - m2-patch                           # [win]
   host:
     - zlib  # [unix]
 
@@ -95,7 +93,15 @@ about:
   license: TCL
   license_family: BSD
   license_file: tcl{{ version }}/license.terms
-  summary: A dynamic programming language with GUI support.  Bundles Tcl and Tk.
+  summary: A dynamic programming language with GUI support. Bundles Tcl and Tk.
+  description: |
+    Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language, 
+    suitable for a very wide range of uses, including web and desktop applications, networking, 
+    administration, testing and many more. Open source and business-friendly, 
+    Tcl is a mature yet evolving language that is truly cross platform, easily deployed and highly extensible.
+    Tk is a graphical user interface toolkit that takes developing desktop applications to a higher level than 
+    conventional approaches. Tk is the standard GUI not only for Tcl, but for many other dynamic languages, 
+    and can produce rich, native applications that run unchanged across Windows, Mac OS X, Linux and more.
   dev_url: https://core.tcl-lang.org/tk/home
   doc_url: https://www.tcl.tk/man/tcl8.6/index.html
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
   - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tk{{ version }}-src.tar.gz
     folder: tk{{ version }}
     sha256: 8ffdb720f47a6ca6107eac2dd877e30b0ef7fac14f3a84ebbd0b3612cee41a94
+    patches:                  # [osx and x86_64]
+      - 0001-osx-lt-11.patch  # [osx and x86_64]
 
 build:
   number: 0
@@ -30,6 +32,7 @@ requirements:
     - {{ cdt('libxcb') }}                # [linux]
     - {{ cdt('libxau') }}                # [linux]
     - make                               # [linux]
+    - patch                              # [osx and x86_64]
   host:
     - zlib  # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.6.12" %}
+{% set version = "8.6.14" %}
 {% set maj_min = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -8,13 +8,13 @@ package:
 source:
   - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tcl{{ version }}-src.tar.gz
     folder: tcl{{ version }}
-    sha256: 26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6
+    sha256: 5880225babf7954c58d4fb0f5cf6279104ce1cd6aa9b71e9a6322540e1c4de66
   - url: https://altushost-swe.dl.sourceforge.net/project/tcl/Tcl/{{ version }}/tk{{ version }}-src.tar.gz
     folder: tk{{ version }}
-    sha256: 12395c1f3fcb6bed2938689f797ea3cdf41ed5cb6c4766eec8ac949560310630
+    sha256: 8ffdb720f47a6ca6107eac2dd877e30b0ef7fac14f3a84ebbd0b3612cee41a94
 
 build:
-  number: 1
+  number: 0
   detect_binary_files_with_prefix: true
   run_exports:
     # pin to major.minor because library names have that info in them


### PR DESCRIPTION
Driver: PKG-4513 authenticode signing - update to 8.6.14
https://anaconda.atlassian.net/browse/PKG-4566

https://wiki.tcl-lang.org/page/Changes+in+Tcl%2FTk+8.6.13
https://wiki.tcl-lang.org/page/Changes+in+Tcl%2FTk+8.6.14

Changes:
- use vs2019, build nmakehlp (helper application included in tcl)
- patch win-64 build to unvendor zlib
- patch osx-64 build:
   The build assumes that if /System/Library/Frameworks/UniformTypeIdentifiers.framework is present, we are building with a compatible SDK. This is not the case, hence commenting this detection.

Note: tcl/tk ships its own patched version of sqlite. So we shouldn't unvendor it, and we should keep tk up-to-date.