### PR TITLE
tk 8.6.14: x11_gui_rebuilds

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 CONDA_BUILD_SYSROOT:            # [osx and x86_64]
-  - /opt/MacOSX10.12.sdk        # [osx and x86_64]
+  - /opt/MacOSX10.14.sdk        # [osx and x86_64]
 
 c_compiler:                     # [win]
 - vs2019                        # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,0 @@
-CONDA_BUILD_SYSROOT:            # [osx and x86_64]
-  - /opt/MacOSX10.14.sdk        # [osx and x86_64]
-
-c_compiler:                     # [win]
-- vs2019                        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - 0001-osx-lt-11.patch  # [osx and x86_64]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   run_exports:
     # pin to major.minor because library names have that info in them
@@ -29,16 +29,15 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    # TODO: map CDT libxau to new X11 package
-    # - { cdt('libxau') }
     - make                               # [linux]
     - patch                              # [osx and x86_64]
     - m2-patch                           # [win]
   host:
     - zlib {{ zlib }}
     - xorg-xorgproto
-    - xorg-libx11
-    - libxcb
+    - xorg-libx11  # [linux]
+    - xorg-libxau
+    - libxcb  # [linux]
   run:
     - zlib # pin through run_exports
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,15 +29,16 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-    - {{ cdt('libx11-devel') }}          # [linux]
-    - {{ cdt('libxcb') }}                # [linux]
-    - {{ cdt('libxau') }}                # [linux]
+    # TODO: map CDT libxau to new X11 package
+    # - { cdt('libxau') }
     - make                               # [linux]
     - patch                              # [osx and x86_64]
     - m2-patch                           # [win]
   host:
     - zlib {{ zlib }}
+    - xorg-xorgproto
+    - xorg-libx11
+    - libxcb
   run:
     - zlib # pin through run_exports
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,10 +34,7 @@ requirements:
     - m2-patch                           # [win]
   host:
     - zlib {{ zlib }}
-    - xorg-xorgproto
     - xorg-libx11  # [linux]
-    - xorg-libxau
-    - libxcb  # [linux]
   run:
     - zlib # pin through run_exports
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7748](https://anaconda.atlassian.net/browse/PKG-7748) 
- [Upstream repository](https://core.tcl-lang.org/tk/home)

### Explanation of changes:

- Bumpt the build number to 1
- Remove an obsolete `cbc.yaml`
- Replace CDTs in `build` by `xorg`/`xcb`/`x11` conda packages in `host`. 

### Notes:

- It's an automated migration/rebuild for the `x11_gui_rebuilds` group:

```
  x11_gui_rebuilds:
    stages:
    - stage: 0
      packages:
      - tk
      - libxkbcommon
      - pango
      - at-spi2-core
      - at-spi2-atk
      - tktable
    - stage: 1
      packages:
      - gtk2
      - gtk3
      - gstreamer
      - harfbuzz
      - cairo
    - stage: 2
      packages:
      - qtbase
      - qtsvg
      - qtimageformats
      - qt5compat
      - qtshadertools
      - qttranslations
    - stage: 3
      packages:
      - qtwebchannel
      - qtwebsockets
      - qtdeclarative
      - qttools
    - stage: 4
      packages:
      - pyqt
      - pyside6
      - wxpython
      - pycairo
    - stage: 5
      packages:
      - glew
      - graphviz
      - jasper
      - gobject-introspection
      - librsvg
    - stage: 6
      packages:
      - qtwebengine
      - vtk
      - opencv
      - poppler
    - stage: 7
      packages:
      - portaudio
      - texlive-core
      - seaborn
```

[PKG-7748]: https://anaconda.atlassian.net/browse/PKG-7748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ